### PR TITLE
Add latest version tag to eliminate warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or download executable file from [releases](https://github.com/bastengao/gncdu/r
 
 ### Install from source
 
-    go install github.com/bastengao/gncdu
+    go install github.com/bastengao/gncdu@latest
 
 ## Usage
 


### PR DESCRIPTION
go: 'go install' requires a version when current directory is not in a module

![image](https://github.com/bastengao/gncdu/assets/44328700/ff9b7f7f-c8a8-4d22-bb1c-89e1e4954a98)
